### PR TITLE
Update slackcoc.md

### DIFF
--- a/docs/versioned_docs/version-2.1.0/contributing-guide/slackcoc.md
+++ b/docs/versioned_docs/version-2.1.0/contributing-guide/slackcoc.md
@@ -60,7 +60,7 @@ In addition, violations of this code outside our spaces may affect a person’s 
 - If violations occur, organizers will take any action they deem appropriate for the infraction, up to and including expulsion.
 
 :::info
-Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](http://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/) under a Creative Commons Attribution-ShareAlike license.
+Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](http://adainitiative.org/) under a Creative Commons Attribution-ShareAlike license.
 :::
 
 ---


### PR DESCRIPTION
Fixed broken URL in slack code of conduct 

From Broken URL: http://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/

To: http://adainitiative.org/